### PR TITLE
Update strings.xml

### DIFF
--- a/values/strings.xml
+++ b/values/strings.xml
@@ -673,7 +673,7 @@
     <string name="title_activity_add_shop_item">Put on Shelves</string>
     <string name="shop_empty_text">No items on the shelves</string>
     <string name="inventory_empty_text">No items in the inventory\nInventory only contains items that are not used yet.</string>
-    <string name="to_do_get_coins">Get Coins:+%1$d</string>
+    <string name="to_do_get_coins">Coins earned: +%1$d</string>
     <string name="xml_add_to_do_coins_title">Coin Reward</string>
     <string name="coin_possess">Owned: %1$d</string>
     <string name="coin_price_own">Coins: %1$d - %2$d</string>
@@ -1850,16 +1850,16 @@ Go to the Shop-Inventory page (4th position of navbar) to open it!</string>
     <string name="sample_task_get_up_early_desc">Start time and deadline time settings can be used to limit the time range of a repeat task.\nBy the way, the default deadline without a specified time (hour, minutes) will be at 0:00 the next day. You can set a specified deadline you want in the next day to change this setting.</string>
 
     <!-- in xx days -->
-    <string name="tag_deadline_v2_relative">Deadline in %1$s</string>
-    <string name="tag_deadline_v2_with_time">Deadline at %1$s</string>
-    <string name="tag_deadline_v2_with_date">Deadline on %1$s</string>
+    <string name="tag_deadline_v2_relative">Due in %1$s</string>
+    <string name="tag_deadline_v2_with_time">Due: %1$s</string>
+    <string name="tag_deadline_v2_with_date">Due: %1$s</string>
     <!-- today/tomorrow/yesterday -->
     <string name="tag_deadline_v2_relative_special">Deadline %1$s</string>
 
     <!-- in xx days -->
     <string name="tag_start_v2_relative">Starts in %1$s</string>
-    <string name="tag_start_v2_with_time">Starts at %1$s</string>
-    <string name="tag_start_v2_with_date">Starts on %1$s</string>
+    <string name="tag_start_v2_with_time">Starts: %1$s</string>
+    <string name="tag_start_v2_with_date">Starts: %1$s</string>
     <!-- today/tomorrow/yesterday -->
     <string name="tag_start_v2_relative_special">Starts %1$s</string>
 


### PR DESCRIPTION
line 676: since this pops up after earning coins, "get" (present tense) doesn't make sense, and "coins earned" is a better representation of what's happening at the time.

lines 1854-1855: line 1854 ("Deadline at") is ungrammatical when the deadline is a specific time (e.g., "deadline at tomorrow"), so I changed it to "Due:". I changed the line to "Due:" as well, because I think it's more succinct (takes up less space) and has less chance of being ungrammatical.

lines 1861-1862: similar to above, "Starts at tomorrow" is ungrammatical, but removing the "on/at" also makes it shorter.

line 363-364: this isn't a translation issue, just a suggestion: "You have a task to complete:" takes up a lot of space in the notification (roughly 2/3 of the notification text on my phone), so a task with medium or long title gest cut off, and the notification cannot be expanded. I think it would be much more efficient for the notification title to be the name of the task, and the description to be the deadline (if there is one; I think this is the most important information to include in a reminder notification). regardless of what you include, the current notification title "LifeUp" and the sentence "You have a task to complete:" doesn't really add any useful information and takes up unnecessary space that could be put to better use.